### PR TITLE
Reference to RFC3986 was incomplete, causes 'rfcmarkup' to fail.

### DIFF
--- a/draft-mbelshe-spdy-00.xml
+++ b/draft-mbelshe-spdy-00.xml
@@ -7,6 +7,7 @@
   <!ENTITY RFC2285 PUBLIC '' 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.2285.xml'>
   <!ENTITY RFC2616 PUBLIC '' 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.2616.xml'>
   <!ENTITY RFC2617 PUBLIC '' 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.2617.xml'>
+  <!ENTITY RFC3986 PUBLIC '' 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.3986.xml'>
   <!ENTITY RFC4559 PUBLIC '' 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.4559.xml'>
   <!ENTITY RFC4366 PUBLIC '' 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.4366.xml'>
   <!ENTITY RFC5246 PUBLIC '' 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.5246.xml'>
@@ -1157,6 +1158,7 @@ Here is a list of the major changes between this draft and draft #2.
       &RFC2285;
       &RFC2616;
       &RFC2617;
+      &RFC3986;
       &RFC4559;
       &RFC4366;
       &RFC5246;


### PR DESCRIPTION
Commit e940e5d3c1cc930e52bd30b7e03f78573c0e04ad replaces a reference
to RFC1738 with a reference to RFC3986. However, it doesn't add an
entity declaration for 'RFC3986' to the DOCTYPE, and doesn't update
the 'Normative References' section. This causes 'rfcmarkup' to
bork partway through processing. Adding the entity declaration and
the reference fixes the problem.
