### PR TITLE
Change GOAWAY status code INTERNAL_ERROR from the arbitrary 11 to a sequential 2

### DIFF
--- a/draft-mbelshe-spdy-00.xml
+++ b/draft-mbelshe-spdy-00.xml
@@ -521,7 +521,7 @@ If a client receives an odd numbered PING which it did not initiate, it must ign
 <list>
 <t>0 - OK. This is a normal session teardown.</t>
 <t>1 - PROTOCOL_ERROR. This is a generic error, and should only be used if a more specific error is not available.</t>
-<t>11 - INTERNAL_ERROR.  This is a generic error which can be used when the implementation has internally failed, not due to anything in the protocol.</t>
+<t>2 - INTERNAL_ERROR.  This is a generic error which can be used when the implementation has internally failed, not due to anything in the protocol.</t>
 </list>
 </t>
         </section>


### PR DESCRIPTION
As discussed on the mailing list, the constant "11" makes little sense if we're not reserving ranges.
